### PR TITLE
Allow custom bind-address

### DIFF
--- a/etc/fregata.conf
+++ b/etc/fregata.conf
@@ -1,3 +1,6 @@
+[http]
+  bind-address = ":2017"
+
 [logging]
   file = "STDOUT"
   level = "INFO"

--- a/http/config.go
+++ b/http/config.go
@@ -1,0 +1,11 @@
+// Package http is only used for configure custom bind address
+package http
+
+type Config struct {
+	BindAddress string `toml:"bind-address"`
+}
+
+func NewConfig() Config {
+
+	return Config{}
+}

--- a/server/config.go
+++ b/server/config.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"github.com/xuqingfeng/fregata/http"
 	"github.com/xuqingfeng/fregata/logging"
 	"github.com/xuqingfeng/fregata/services/macos"
 	"github.com/xuqingfeng/fregata/services/slack"
@@ -11,6 +12,7 @@ import (
 )
 
 type Config struct {
+	HTTP     http.Config     `toml:"http"`
 	Logging  logging.Config  `toml:"logging"`
 	Slack    slack.Config    `toml:"slack"`
 	Macos    macos.Config    `toml:"macos"`
@@ -22,6 +24,7 @@ type Config struct {
 func NewConfig() *Config {
 
 	c := &Config{}
+	c.HTTP = http.NewConfig()
 	c.Logging = logging.NewConfig()
 	c.Slack = slack.NewConfig()
 	c.Macos = macos.NewConfig()

--- a/server/server.go
+++ b/server/server.go
@@ -50,7 +50,7 @@ func New(c *Config, logService logging.Interface) (*Server, error) {
 		s.appendWechatService()
 	}()
 
-	if err := http.ListenAndServe(":2017", router); err != nil {
+	if err := http.ListenAndServe(c.HTTP.BindAddress, router); err != nil {
 		return nil, fmt.Errorf("%s", err)
 	}
 


### PR DESCRIPTION
Restrict the listen address to be localhost:

```toml
# fregata.conf
[http]
  bind-address = "127.0.0.1:2017"
```

